### PR TITLE
Allow making JSON requests via Guzzle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,15 @@ Releases prior to 1.2.0 did not have entries.
 
 ### Changed
 
-- Nothing.
+- [#90](https://github.com/zendframework/zenddiagnostics/pull/90) modifies what types are allowed for the `GuzzleHttpService` initial constructor
+  argument. Previously, it only allowed a URL; it now allow any valid request instance the Guzzle client
+  can accept. This change allows you to craft a custom request to send.
+
+- [#90](https://github.com/zendframework/zenddiagnostics/pull/90) modifies the behavior of `GuzzleHttpService` slightly in relation to how
+  it handles its `$body` argument. It now allows stream instances, any object implementing `__toString()`,
+  any iterator objects, any `JsonSerializable` objects, and strings and arrays. In the latter case, it
+  checks to see if the request `Content-Type` is JSON, casting the value to JSON if so, and otherwise
+  serializing it as form-encoded data.
 
 ### Deprecated
 

--- a/docs/book/diagnostics.md
+++ b/docs/book/diagnostics.md
@@ -192,8 +192,37 @@ $checkPageContent = new HttpService(
 ## GuzzleHttpService
 
 Attempt connection to a given HTTP host or IP address and try to load a web page
-using [Guzzle](http://guzzle3.readthedocs.org/en/latest/). The check also
-supports checking response codes and page contents.
+using [Guzzle](http://docs.guzzlephp.org). The check also supports checking
+response codes and page contents.
+
+The constructor signature of the `GuzzleHttpService` is as follows:
+
+```php
+/**
+ * @param string|Psr\Http\Message\RequestInterface|GuzzleHttp\Message\RequestInterface $requestOrUrl
+ *     The absolute url to check, or a fully-formed request instance.
+ * @param array $headers An array of headers used to create the request
+ * @param array $options An array of guzzle options to use when sending the request
+ * @param int $statusCode The response status code to check
+ * @param null $content The response content to check
+ * @param null|GuzzleHttp\ClientInterface $guzzle Instance of guzzle to use
+ * @param string $method The method of the request
+ * @param mixed $body The body of the request (used for POST, PUT and DELETE requests)
+ * @throws InvalidArgumentException
+ */
+public function __construct(
+    $requestOrUrl,
+    array $headers = [],
+    array $options = [],
+    $statusCode = 200,
+    $content = null,
+    $guzzle = null,
+    $method = 'GET',
+    $body = null
+)
+```
+
+Examples:
 
 ```php
 <?php
@@ -227,6 +256,33 @@ $checkPageContent = new GuzzleHttpService(
     'POST',
     ['post_field' => 'post_value']
 );
+```
+
+You can send JSON data by either providing a `Content-Type` header that includes
+a JSON content type, or creating a request instance with JSON content:
+
+```php
+// Send page content
+$checkPageContent = new GuzzleHttpService(
+    'api.example.com/ping',
+    ['Content-Type' => 'application/json'],
+    [],
+    200,
+    null,
+    null,
+    'POST',
+    ['ping' => microtime()]
+);
+
+// Assuming Guzzle 6:
+use GuzzleHttp\Psr7\Request;
+$request = new Request(
+    'POST',
+    'http://api.example.com/ping',
+    ['Content-Type' => 'application/json'],
+    json_encode(['ping' => microtime()])
+);
+$checkPageContent = new GuzzleHttpService($request);
 ```
 
 ## Memcache


### PR DESCRIPTION
This patch fixes #87, allowing users to make JSON requests via the `GuzzleHttpService`. In fact, it goes a step further, and allows passing a fully formed request instance to the `GuzzleHttpService` constructor, allowing full customization of the request to send.