### PR TITLE
Demonstrates emitting an appropriate status code on exit

### DIFF
--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -88,7 +88,11 @@ $runner->addCheck(new Check\DiskFree(100000000, '/tmp'));
 $runner->addReporter(new BasicConsole(80, true));
 
 // Run all checks
-$runner->run();
+$results = $runner->run();
+
+// Emit an appropriate exit code
+$status = ($results->getFailureCount() + $results->getWarningCount()) > 0 ? 1 : 0;
+exit($status);
 ```
 
 You can now run the file in your console (command line):


### PR DESCRIPTION
The runner returns a results collection, and this class has methods for determining how may failures, warnings, skipped tests, unknown results, and success results were encountered. We can add warnings and failures to determine if they are a non-zero number, and, if so, exit with a status of 1.

Fixes #86