### PR TITLE
Add apcu compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   global:
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
+    - TESTS_ZEND_DIAGNOSTICS_APCU_ENABLED=true
     - TESTS_ZEND_DIAGNOSTICS_MONGO_ENABLED=true
     - TESTS_ZEND_DIAGNOSTICS_RABBITMQ_ENABLED=true
     - TESTS_ZEND_DIAGNOSTICS_REDIS_ENABLED=true
@@ -26,6 +27,7 @@ matrix:
       env:
         - DEPS=lowest
         - MONGO_LEGACY=true
+        - TESTS_ZEND_DIAGNOSTICS_APCU_ENABLED=false
         - TESTS_ZEND_DIAGNOSTICS_MEMCACHE_ENABLED=true
         - TESTS_ZEND_DIAGNOSTICS_MEMCACHED_ENABLED=false
     - php: 5.6
@@ -33,12 +35,14 @@ matrix:
         - DEPS=locked
         - MONGO_LEGACY=true
         - LEGACY_DEPS="phpunit/phpunit"
+        - TESTS_ZEND_DIAGNOSTICS_APCU_ENABLED=false
         - TESTS_ZEND_DIAGNOSTICS_MEMCACHE_ENABLED=true
         - TESTS_ZEND_DIAGNOSTICS_MEMCACHED_ENABLED=false
     - php: 5.6
       env:
         - DEPS=latest
         - MONGO_LEGACY=true
+        - TESTS_ZEND_DIAGNOSTICS_APCU_ENABLED=false
         - TESTS_ZEND_DIAGNOSTICS_MEMCACHE_ENABLED=true
         - TESTS_ZEND_DIAGNOSTICS_MEMCACHED_ENABLED=false
     - php: 7
@@ -83,6 +87,7 @@ matrix:
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+  - if [[ $TESTS_ZEND_DIAGNOSTICS_APCU_ENABLED == 'true' ]]; then echo "extension = apcu.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
   - if [[ $TESTS_ZEND_DIAGNOSTICS_MEMCACHE_ENABLED == 'true' ]]; then echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
   - if [[ $TESTS_ZEND_DIAGNOSTICS_MEMCACHED_ENABLED == 'true' ]]; then echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi
   - if [[ $MONGO_LEGACY == 'true' ]]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ Releases prior to 1.2.0 did not have entries.
 
 ### Added
 
+- [#93](https://github.com/zendframework/zenddiagnostics/pull/93) adds compatibility for apcu
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 1.2.1 - TBD
+
+### Added
+
 - Nothing.
 
 ### Changed

--- a/src/Check/ApcFragmentation.php
+++ b/src/Check/ApcFragmentation.php
@@ -14,9 +14,9 @@ use ZendDiagnostics\Result\Success;
 use ZendDiagnostics\Result\Warning;
 
 /**
- * Checks to see if the APC fragmentation is below warning/critical thresholds
+ * Checks to see if the APCu fragmentation is below warning/critical thresholds
  *
- * APC memory logic borrowed from APC project:
+ * APCu memory logic borrowed from APC project:
  *
  *      https://github.com/php/pecl-caching-apc/blob/master/apc.php
  *      authors:   Ralf Becker <beckerr@php.net>, Rasmus Lerdorf <rasmus@php.net>, Ilia Alshanetsky <ilia@prohost.org>
@@ -90,11 +90,11 @@ class ApcFragmentation extends AbstractCheck implements CheckInterface
             return new Skip('APC has not been enabled in CLI.');
         }
 
-        if (! function_exists('apc_sma_info')) {
-            return new Warning('APC extension is not available');
+        if (! function_exists('apcu_sma_info')) {
+            return new Warning('APCu extension is not available');
         }
 
-        if (! $info = apc_sma_info()) {
+        if (! $info = apcu_sma_info()) {
             return new Warning('Unable to retrieve APC memory status information.');
         }
 

--- a/src/Check/ApcMemory.php
+++ b/src/Check/ApcMemory.php
@@ -13,9 +13,9 @@ use ZendDiagnostics\Result\Success;
 use ZendDiagnostics\Result\Warning;
 
 /**
- * Checks to see if the APC memory usage is below warning/critical thresholds
+ * Checks to see if the APCu memory usage is below warning/critical thresholds
  *
- * APC memory logic borrowed from APC project:
+ * APCu memory logic borrowed from APC project:
  *      https://github.com/php/pecl-caching-apc/blob/master/apc.php
  *      authors:   Ralf Becker <beckerr@php.net>, Rasmus Lerdorf <rasmus@php.net>, Ilia Alshanetsky <ilia@prohost.org>
  *      license:   The PHP License, version 3.01
@@ -46,11 +46,14 @@ class ApcMemory extends AbstractMemoryCheck
             return new Skip('APC has not been enabled in CLI.');
         }
 
-        if (! function_exists('apc_sma_info')) {
-            return new Warning('APC extension is not available');
+        if (! function_exists('apcu_sma_info')) {
+            return new Warning(sprintf(
+                '%s extension is not available',
+                PHP_VERSION_ID < 70000 ? 'APC' : 'APCu'
+            ));
         }
 
-        if (! $this->apcInfo = apc_sma_info()) {
+        if (! $this->apcInfo = apcu_sma_info()) {
             return new Warning('Unable to retrieve APC memory status information.');
         }
 


### PR DESCRIPTION
We wanted to use the APC fragmentation/memory checks, but since we use `apcu` I always received the error `APC extension is not available`, thus I added a version check and based on that I use the correct method (`apc_sma_info` vs `apcu_sma_info`).

