### PR TITLE
Initialize result message with empty string instead of null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file, in reverse 
 
 Releases prior to 1.2.0 did not have entries.
 
+## 1.3.2 - 2018-09-16
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- AbstractResult message default value is empty string.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 1.3.1 - TBD
 
 ### Added

--- a/src/Result/AbstractResult.php
+++ b/src/Result/AbstractResult.php
@@ -13,7 +13,7 @@ namespace ZendDiagnostics\Result;
 abstract class AbstractResult implements ResultInterface
 {
     /**
-     * @var string|null
+     * @var string
      */
     protected $message;
 
@@ -25,14 +25,12 @@ abstract class AbstractResult implements ResultInterface
     /**
      * Create new result
      *
-     * @param string|null $message
+     * @param string      $message
      * @param mixed|null  $data
      */
-    public function __construct($message = null, $data = null)
+    public function __construct($message = '', $data = null)
     {
-        if ($message !== null) {
-            $this->setMessage($message);
-        }
+        $this->setMessage($message);
 
         if ($data !== null) {
             $this->setData($data);
@@ -68,7 +66,7 @@ abstract class AbstractResult implements ResultInterface
     }
 
     /**
-     * @param null|string $message
+     * @param string $message
      */
     public function setMessage($message)
     {


### PR DESCRIPTION
Related to https://github.com/liip/LiipMonitorBundle/pull/193


Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
No, just an inconsistency between an interface and abstract implementation

- [ ] Detail how the bug is invoked currently.
See https://github.com/liip/LiipMonitorBundle/pull/193

- [ ] Detail the original, incorrect behavior.
Namespace: ZendDiagnostics\Result
ResultInterface defines message property as a non-nullable string.
In AbstractResult it's defined/used as null|string.

- [ ] Detail the new, expected behavior.
Initialize message as empty string.

- [ ] Base your feature on the `master` branch, and submit against that branch.
Done.

- [ ] Add a regression test that demonstrates the bug, and proves the fix.
It wasn't covered with test, but the change doesn't require test IMO.

- [ ] Add a `CHANGELOG.md` entry for the fix.
Done.

- [ ] Are you creating a new feature?
No.

- [ ] Is this related to quality assurance?
No.

- [ ] Is this related to documentation?
No.
